### PR TITLE
Update for node 0.10.x and 0.12.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,15 +25,14 @@
   "main": "index",
   "test": "make test",
   "engines": {
-    "node": ">= 0.4.x < 0.7.0",
-    "npm": "1"
+    "node": ">= 0.10.x < 0.13.0"
   },
   "dependencies": {
 
   },
   "devDependencies": {
-    "mocha": "1.0.x",
-    "should": "0.6.x"
+    "mocha": "^2.1.0",
+    "should": "^5.0.0"
   },
   "licenses": [
     {


### PR DESCRIPTION
I updated the devDependencies to be able to run the test in node 0.12; I also checked with node 0.10 and 0.11 and it works, so I updated the engines to specify that range.

Bear in mind that I haven't bumped the package version, you should do to avoid to break packages which depend of it and they are still running with old node versions. Not sure if you should bump the package to major or minor, I guess that major should be reliable not break dependant packages.